### PR TITLE
Simplify bootstrap classes and styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,36 +16,28 @@
   <canvas id="scratch" hidden></canvas>
   <script src="./index.js"></script>
 
-  <div class="px-4 py-5 my-5 text-center">
-    <h1 class="display-5 fw-bold text-white text-shadow">Unmessup the Metaverse</h1>
-    <div class="col-lg-7 mx-auto">
-      <p class="lead text-white text-shadow">Nudging people towards interoperable worlds</p>
-      <div class="container px-4 py-5" id="custom-cards">
-          <div class="row row-cols-1 row-cols-lg-3 align-items-stretch g-4 py-5">
-            <div class="col">
-              <div class="card card-cover h-100 overflow-hidden text-white rounded-5 shadow-lg" style="background-image: url('images/avatar-player.png'); background-size: auto 160%; background-position: 0%;">
-                <div class="d-flex mt-5 pt-5 flex-column h-100 text-white text-shadow">
-                  <h2 class="mt-4 display-7 lh-1">Players</h2>
-                </div>
-              </div>
-            </div>
-            <div class="col">
-              <div class="card card-cover h-100 overflow-hidden text-white rounded-5 shadow-lg" style="background-image: url('images/avatar-builder.png'); background-size: auto 147%; background-position: 50%;">
-                <div class="d-flex mt-5 pt-5 flex-column h-100 text-white text-shadow">
-                  <h2 class="mt-4 display-7 lh-1">Builders</h2>
-                </div>
-              </div>
-            </div>
-            <div class="col">
-              <div class="card card-cover h-100 overflow-hidden text-white rounded-5 shadow-lg" style="background-image: url('images/avatar-coder.png'); background-size: auto 158%; background-position: 60%;">
-                <div class="d-flex mt-5 pt-5 flex-column h-100 text-shadow">
-                  <h2 class="mt-4 display-7 lh-1">Coders</h2>
-                </div>
-              </div>
-            </div>
-          </div>
+  <div class="header">
+    <h1 class="text-shadow">Unmessup the Metaverse</h1>
+    <p class="lead text-shadow">Nudging people towards interoperable worlds</p>
+  </div>
+  <div class="category-container">
+    <div class="category-cards" id="custom-cards">
+      <div id="players" class="category-card">
+        <div class="category-card-title">
+          <h2>Players</h2>
         </div>
-    </div>
+      </div>
+      <div id="builders" class="category-card" >
+        <div class="category-card-title">
+          <h2>Builders</h2>
+        </div>
+      </div>
+      <div id="coders" class="category-card">
+        <div class="category-card-title">
+          <h2>Coders</h2>
+        </div>
+      </div>
+    </div>  
   </div>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,14 +1,21 @@
-html {
-  background: black;
-  height: 100%;
-  overflow: hidden;
-}
-
 body {
-  background: transparent;
+  background: black;
   margin: 0;
   padding: 0;
   height: 100%;
+  overflow: hidden;
+  color: white;
+}
+
+h1 {
+  font-size: calc(1.425rem + 2.1vw);
+  line-height: 1.2;
+  font-weight: 700!important;
+}
+
+h2 {
+  margin: 0.25rem 0px;
+  text-align: center!important;
 }
 
 #matrix {
@@ -39,7 +46,6 @@ body {
   height: 4rem;
   margin-bottom: 1rem;
   font-size: 2rem;
-  color: #fff;
   border-radius: .75rem;
 }
 
@@ -72,15 +78,92 @@ body {
 
 .text-shadow { text-shadow: 0 0 4px rgba(0, 0, 0, 1); }
 
-.card-cover {
-  background-color: rgba(16, 8, 24, 0.65);
-  background-repeat: no-repeat;
-  background-position: center center;
-  background-size: cover;
-  border: 1px solid #302040;
+.header {
+  height: calc(max(30vh, max-content));
+  padding: 5rem 2rem 1rem 2rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: end;
+  text-align: center;
 }
 
-.card-cover:hover {
+.category-container {
+  height: 70vh;
+  overflow-y: scroll;
+  display: flex;
+  flex-wrap: nowrap;
+}
+
+.category-cards {
+  height: 100%;
+  display: flex;
+  flex-wrap: nowrap;
+  justify-content: space-between;
+  min-width: 768px;
+  max-width: 768px;
+  padding: 6rem 0.75rem;
+  margin: auto;
+}
+
+.category-card {
+  margin: 0.75rem;
+  height: 156px;
+  min-width: 224px;
+  overflow: hidden;
+  color: white;
+  border-radius: 1rem;
+  background-color: rgba(16, 8, 24, 0.65);
+  background-repeat: no-repeat;
+  border: 1px solid #302040;
+  box-shadow: 0 1rem 3rem rgba(0,0,0,0.175)!important;
+}
+
+.category-card:hover {
   background-color: rgba(32, 16, 48, 0.65);
   border: 1px solid #9060b0;
+}
+
+.category-card-title {
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  align-items: flex-end;
+  color: white;
+  text-shadow: 0 0 4px rgb(0 0 0);
+}
+
+.category-card#players {
+  background-image: url(images/avatar-player.png); 
+  background-size: auto 160%;
+  background-position: -10%;
+}
+
+.category-card#builders {
+  background-image: url(images/avatar-builder.png); 
+  background-size:  auto 147%;
+  background-position: 50%;
+}
+
+.category-card#coders {
+  background-image: url(images/avatar-coder.png); 
+  background-size:  auto 158%;
+  background-position: 60%;
+}
+
+@media only screen and (max-width: 767px) {
+  body {
+    background: black;
+    height: 100%;
+  }
+
+  .category-cards {
+    flex-wrap: wrap;
+    align-content: start;
+    padding: 1rem 0.75rem;
+    min-width: 100vw;
+  }
+
+  .category-card {
+    margin: 0.75rem calc(50vw - 112px - 0.75rem);
+  }
 }


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

Hi there! I came across this issue while looking for projects to practice CSS refactoring and wasn't quite sure if this still needed work (the current UI *is* responsive, it just doesn't look similar to the screenshot at smaller viewport widths due to the way bootstrap cards and containers work.) 

I did notice some opportunities for simplifying the code and circumventing some of the 'responsive' styling that bootstrap forces onto pages (for example, avoiding cards becoming full-width at smaller viewport widths.)

Is something like this what you were looking for?
Mobile:
<img width="35%" alt="Screen Shot 2021-12-28 at 5 57 02 PM" src="https://user-images.githubusercontent.com/84106309/147610237-e24a3992-95fb-4015-98e7-4d1954861bea.png">

Tablet:
<img width="50%" alt="Screen Shot 2021-12-28 at 5 56 48 PM" src="https://user-images.githubusercontent.com/84106309/147610241-af14a334-e0a6-4332-a10b-d9a721b39ef1.png">

Desktop
<img width="100%" alt="Screen Shot 2021-12-28 at 5 56 32 PM" src="https://user-images.githubusercontent.com/84106309/147610248-5d06411f-e563-41ce-b0f5-5044e5e8cd29.png">

